### PR TITLE
remove wildcard in collection script data file search

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -11,7 +11,7 @@ DATA_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "dat
 def data_files(data, data_path):
     files = []
     for item in data:
-        files.extend(glob.glob(os.path.join(data_path, f"{item}*.json")))
+        files.extend(glob.glob(os.path.join(data_path, f"{item}.json")))
     return files
 
 


### PR DESCRIPTION
This wildcard was causing e.g. 

```
poetry run insert-collection GEDI_CalVal_Lidar_Data
```

to run insertion on 

```
GEDI_CalVal_Lidar_Data
GEDI_CalVal_Lidar_Data_compressed
```

whereas I only want GEDI_CalVal_Lidar_Data. I removed the wildcard, and we can now always do 

```
poetry run insert-collection GEDI_CalVal_Lidar_Data*
```

to get the same behavior. 