### PR TITLE
infer thumbnails from CMR browse link

### DIFF
--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -206,7 +206,7 @@ def _roles(link: str, asset_roles: Union[list, dict], default: List[str]) -> Lis
     else:
         return asset_roles
 
-
+# TODO the `roles` parameter type hint is wrong.
 def generate_asset(
     roles: Union[str, Dict[str, List[str]]],
     link: dict,
@@ -281,14 +281,13 @@ def from_cmr_links(cmr_links, item) -> Tuple[List, Dict[str, pystac.Asset]]:
             )
         if link["rel"].endswith("browse#"):
             asset = generate_asset(
-                "thumbnail",
+                ["thumbnail"],
                 link,
                 item
             )
             if asset:
-                # grab the file name to use as id, in case there are multiple thumbnails
-                fname = link["href"].split("/")[-1].split(".")[0]
-                assets[f'thumbnail-{fname}'] = asset
+                # name the asset after the href
+                assets[link["href"]] = asset
     if item.assets:
         # Removes the default data asset, exists as a duplicate
         del assets["data"]

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -206,6 +206,7 @@ def _roles(link: str, asset_roles: Union[list, dict], default: List[str]) -> Lis
     else:
         return asset_roles
 
+
 # TODO the `roles` parameter type hint is wrong.
 def generate_asset(
     roles: Union[str, Dict[str, List[str]]],
@@ -280,11 +281,7 @@ def from_cmr_links(cmr_links, item) -> Tuple[List, Dict[str, pystac.Asset]]:
                 )
             )
         if link["rel"].endswith("browse#"):
-            asset = generate_asset(
-                ["thumbnail"],
-                link,
-                item
-            )
+            asset = generate_asset(["thumbnail"], link, item)
             if asset:
                 # name the asset after the href
                 assets[link["href"]] = asset

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -279,7 +279,16 @@ def from_cmr_links(cmr_links, item) -> Tuple[List, Dict[str, pystac.Asset]]:
                     "documentation", link["href"], link.get("type"), link.get("title")
                 )
             )
-
+        if link["rel"].endswith("browse#"):
+            asset = generate_asset(
+                "thumbnail",
+                link,
+                item
+            )
+            if asset:
+                # grab the file name to use as id, in case there are multiple thumbnails
+                fname = link["href"].split("/")[-1].split(".")[0]
+                assets[f'thumbnail-{fname}'] = asset
     if item.assets:
         # Removes the default data asset, exists as a duplicate
         del assets["data"]


### PR DESCRIPTION
When looping over CMR granule links, added a "#browse" case, which identifies links to images that should be used as [STAC "thumbnails"](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#asset-roles). We add any of these as assets to the item, with the "thumbnail" role, and with as a name the URL to the file (since there can be multiple such files).

Tested. Deployed on both test and dev stacks. Published ALOS_PSR_RTC_HIGH and ABoVE_UAVSAR_PALSAR with this. 