### PR TITLE
Add nasa jpl global agb mean 2020

### DIFF
--- a/data/collections/NASA_JPL_global_agb_mean_2020.json
+++ b/data/collections/NASA_JPL_global_agb_mean_2020.json
@@ -1,0 +1,31 @@
+{
+    "id": "NASA_JPL_global_agb_mean_2020",
+    "stac_version": "1.0.0",
+    "license": "not-provided",
+    "title": "NASA JPL Global Above Ground Biomass Mean Prediction 2020",
+    "type": "Collection",
+    "description": "NASA JPL Global Above Ground Biomass Mean Prediction 2020",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2020-01-01T00:00:00.000Z",
+            "2020-12-31T23:59:59.999Z"
+          ]
+        ]
+      }
+    },
+    "links": [],
+    "item_assets": {}
+  }
+  

--- a/data/step_function_inputs/NASA_JPL_global_agb_mean_2020.json
+++ b/data/step_function_inputs/NASA_JPL_global_agb_mean_2020.json
@@ -1,0 +1,7 @@
+{
+    "collection": "NASA_JPL_global_agb_mean_2020",
+    "discovery": "inventory",
+    "inventory_url": "s3://maap-user-shared-data/nasa_jpl_global_agb_mean_2020/inventory.csv",
+    "cogify": false,
+    "upload": false
+}

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -19,7 +19,6 @@ from . import events, regex, role
 def create_item(
     id,
     properties,
-    links,
     datetime,
     item_url,
     collection,
@@ -30,6 +29,7 @@ def create_item(
     asset_name=None,
     asset_roles=None,
     asset_media_type=None,
+    links=None
 ) -> pystac.Item:
     """
     Function to create a stac item from a COG using rio_stac
@@ -45,6 +45,8 @@ def create_item(
             collection=collection,
             bbox=bbox,
         )
+        if links is None:
+            raise ValueError("links must be provided")
         stac_item.links.extend(links)
         stac_item.assets = assets
         return stac_item

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -45,9 +45,8 @@ def create_item(
             collection=collection,
             bbox=bbox,
         )
-        if links is None:
-            raise ValueError("links must be provided")
-        stac_item.links.extend(links)
+        if links:
+            stac_item.links.extend(links)
         stac_item.assets = assets
         return stac_item
 

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -29,7 +29,7 @@ def create_item(
     asset_name=None,
     asset_roles=None,
     asset_media_type=None,
-    links=None
+    links=None,
 ) -> pystac.Item:
     """
     Function to create a stac item from a COG using rio_stac


### PR DESCRIPTION
Also fixes a bug in build-stac introduced by https://github.com/MAAP-Project/veda-data-pipelines/pull/21. I make the `links` argument optional in `create_item`. When we use rio_stac, some links are inferred downstream. 