### PR TITLE
Updating lambdas for generating stac records for icesat2-boreal training data

### DIFF
--- a/data/step_function_inputs/icesat2-boreal.json
+++ b/data/step_function_inputs/icesat2-boreal.json
@@ -2,11 +2,11 @@
     "collection": "icesat2-boreal",
     "inventory_url": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/AGB_tindex_master_train_data.csv",
     "discovery": "inventory",
-    "upload": true,
+    "upload": false,
     "asset_roles": ["data"],
     "asset_media_type": {
             "tif": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "csv": "application/octet-stream",
+            "csv": "text/csv"
         },
     "asset_name": "tif",
     "csv_file_url_key": "s3_path_train"

--- a/data/step_function_inputs/icesat2-boreal.json
+++ b/data/step_function_inputs/icesat2-boreal.json
@@ -1,6 +1,13 @@
 {
     "collection": "icesat2-boreal",
-    "inventory_url": "s3://maap-ops-workspace/shared/lduncanson/DPS_tile_lists/2023/AGB_tindex_master.csv",
+    "inventory_url": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/AGB_tindex_master_train_data.csv",
     "discovery": "inventory",
-    "upload": true
+    "upload": true,
+    "asset_roles": ["data"],
+    "asset_media_type": {
+            "tif": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "csv": "application/octet-stream",
+        },
+    "asset_name": "tif",
+    "csv_file_url_key": "s3_path_train"
 }

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import smart_open
 from utils import events, stac
+import pystac
 
 
 class S3LinkOutput(TypedDict):
@@ -55,40 +56,23 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
-    sample_event = {
-        "collection": "GEDI02_A",
-        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/GEDI02_A___002/2020.12.31/GEDI02_A_2020366232302_O11636_02_T08595_02_003_02_V002.h5",
-        "granule_id": "G1201782029-NASA_MAAP",
-        "id": "G1201782029-NASA_MAAP",
-        "mode": "cmr",
-        "test_links": None,
-        "reverse_coords": None,
-        "asset_name": "data",
-        "asset_roles": ["data"],
-        "asset_media_type": "application/x-hdf5",
-    }
-    print(json.dumps(handler(sample_event, {}), indent=2))
-
+    
     asset_event = {
-        "collection": "AfriSAR_UAVSAR_KZ",
-        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/AfriSAR_UAVSAR_KZ___1/uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz.hdr",
-        "granule_id": "G1200110083-NASA_MAAP",
-        "id": "G1200110083-NASA_MAAP",
-        "mode": "cmr",
-        "test_links": None,
-        "reverse_coords": None,
-        "asset_name": "data",
-        "asset_roles": ["data"],
-        "asset_media_type": {
-            "vrt": "application/octet-stream",
-            "bin": "binary/octet-stream",
-            "hdr": "binary/octet-stream",
+      "collection": "icesat2-boreal",
+      "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831.tif",
+      "upload": True,
+      "user_shared": False,
+      "properties": None,
+      "asset_roles": ["data"],
+      "asset_name":"tif",
+      "asset_media_type": {
+            "tif": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "csv": "application/octet-stream",
         },
-        "assets": {
-            "bin": "s3://nasa-maap-data-store/file-staging/nasa-map/AfriSAR_UAVSAR_KZ___1/uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz.bin",
-            "hdr": "s3://nasa-maap-data-store/file-staging/nasa-map/AfriSAR_UAVSAR_KZ___1/uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz.hdr",
-            "vrt": "s3://nasa-maap-data-store/file-staging/nasa-map/AfriSAR_UAVSAR_KZ___1/uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz.vrt",
-        },
-        "product_id": "uavsar_AfriSAR_v1-coreg_fine_lopenp_14043_16008_140_009_160225_kz",
+      "assets": {
+        "train_data": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831_train_data.csv"
+      },
+      "product_id": "boreal_agb_202302061675671806_3831"
     }
+    
     print(json.dumps(handler(asset_event, {}), indent=2))

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -56,7 +56,6 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
-
     asset_event = {
         "collection": "icesat2-boreal",
         "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831.tif",

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -4,9 +4,9 @@ from sys import getsizeof
 from typing import Any, Dict, TypedDict, Union
 from uuid import uuid4
 
+import pystac
 import smart_open
 from utils import events, stac
-import pystac
 
 
 class S3LinkOutput(TypedDict):
@@ -56,23 +56,23 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 
 if __name__ == "__main__":
-    
+
     asset_event = {
-      "collection": "icesat2-boreal",
-      "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831.tif",
-      "upload": True,
-      "user_shared": False,
-      "properties": None,
-      "asset_roles": ["data"],
-      "asset_name":"tif",
-      "asset_media_type": {
+        "collection": "icesat2-boreal",
+        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831.tif",
+        "upload": True,
+        "user_shared": False,
+        "properties": None,
+        "asset_roles": ["data"],
+        "asset_name": "tif",
+        "asset_media_type": {
             "tif": "image/tiff; application=geotiff; profile=cloud-optimized",
             "csv": "application/octet-stream",
         },
-      "assets": {
-        "train_data": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831_train_data.csv"
-      },
-      "product_id": "boreal_agb_202302061675671806_3831"
+        "assets": {
+            "train_data": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831_train_data.csv"
+        },
+        "product_id": "boreal_agb_202302061675671806_3831",
     }
-    
+
     print(json.dumps(handler(asset_event, {}), indent=2))

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -71,17 +71,19 @@ def create_item(
                     or "image/tiff; application=geotiff; profile=cloud-optimized"
                 ),
             )
-            
+
             if assets:
                 pystac_asset = lambda link: pystac.Asset(
                     roles=_roles(link, asset_roles, ["data"]),
                     href=link,
                     media_type=_content_type(link, asset_media_type),
                 )
-                pystac_assets = {key: pystac_asset(value) for key, value in assets.items()}
-        
+                pystac_assets = {
+                    key: pystac_asset(value) for key, value in assets.items()
+                }
+
             stac_record.assets = dict(stac_record.assets | pystac_assets)
-        
+
             return stac_record
         except Exception as e:
             print(f"Caught exception {e}")

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -45,7 +45,8 @@ def create_item(
             collection=collection,
             bbox=bbox,
         )
-        stac_item.links.extend(links)
+        if links:
+            stac_item.links.extend(links)
         stac_item.assets = assets
         return stac_item
 
@@ -55,7 +56,7 @@ def create_item(
         try:
             # `stac.create_stac_item` tries to opon a dataset with rasterio.
             # if that fails (since not all items are rasterio-readable), fall back to pystac.Item
-            return stac.create_stac_item(
+            stac_record = stac.create_stac_item(
                 id=id,
                 source=item_url,
                 collection=collection,
@@ -63,14 +64,25 @@ def create_item(
                 properties=properties,
                 with_proj=True,
                 with_raster=True,
-                assets=assets,
                 asset_name=asset_name or "cog_default",
                 asset_roles=asset_roles or ["data", "layer"],
                 asset_media_type=(
-                    asset_media_type
+                    _content_type(item_url, asset_media_type)
                     or "image/tiff; application=geotiff; profile=cloud-optimized"
                 ),
             )
+            
+            if assets:
+                pystac_asset = lambda link: pystac.Asset(
+                    roles=_roles(link, asset_roles, ["data"]),
+                    href=link,
+                    media_type=_content_type(link, asset_media_type),
+                )
+                pystac_assets = {key: pystac_asset(value) for key, value in assets.items()}
+        
+            stac_record.assets = dict(stac_record.assets | pystac_assets)
+        
+            return stac_record
         except Exception as e:
             print(f"Caught exception {e}")
             if "not recognized as a supported file format" in str(e):
@@ -141,6 +153,9 @@ def generate_stac_regexevent(item: events.RegexEvent) -> pystac.Item:
         asset_name=item.asset_name,
         asset_roles=item.asset_roles,
         asset_media_type=item.asset_media_type,
+        assets=item.assets,
+        mode=item.mode,
+        links=[],
     )
 
 

--- a/lambdas/inventory/handler.py
+++ b/lambdas/inventory/handler.py
@@ -1,10 +1,11 @@
 import json
 import os
-import re
 import pprint
-import boto3
+import re
 from csv import DictReader
 from urllib.parse import urlparse
+
+import boto3
 
 
 def assume_role(role_arn, session_name):
@@ -65,10 +66,10 @@ def handler(event, context):
                 "upload": event.get("upload", False),
                 "user_shared": event.get("user_shared", False),
                 "properties": event.get("properties", None),
-                "assets" : {
+                "assets": {
                     "train_data": csv_filename,
                 },
-                "product_id" : os.path.splitext(filename)[0].split('/')[-1],
+                "product_id": os.path.splitext(filename)[0].split("/")[-1],
             }
             payload["objects"].append(file_obj)
             file_obj_size = len(json.dumps(file_obj, ensure_ascii=False).encode("utf8"))
@@ -87,7 +88,7 @@ if __name__ == "__main__":
         "file_url_key": "s3_path",
         "csv_file_url_key": "s3_path_train",
         "upload": True,
-        "asset_name": "tif"
+        "asset_name": "tif",
     }
 
     handler(sample_event, {})

--- a/lambdas/inventory/handler.py
+++ b/lambdas/inventory/handler.py
@@ -19,6 +19,7 @@ def assume_role(role_arn, session_name):
 def handler(event, context):
     inventory_url = event.get("inventory_url")
     file_url_key = event.get("file_url_key", "s3_path")
+    csv_file_url_key = event.get("csv_file_url_key", "s3_path_train")
     parsed_url = urlparse(inventory_url, allow_fragments=False)
     bucket = parsed_url.netloc
     inventory_filename = parsed_url.path.strip("/")
@@ -52,6 +53,7 @@ def handler(event, context):
         list_of_dict = list(dict_reader)
         for file_dict in list_of_dict[start_after:]:
             filename = file_dict[file_url_key]
+            csv_filename = file_dict[csv_file_url_key]
             if filename_regex and not re.match(filename_regex, filename):
                 continue
             if file_objs_size > 230000:
@@ -63,23 +65,29 @@ def handler(event, context):
                 "upload": event.get("upload", False),
                 "user_shared": event.get("user_shared", False),
                 "properties": event.get("properties", None),
+                "assets" : {
+                    "train_data": csv_filename,
+                },
+                "product_id" : os.path.splitext(filename)[0].split('/')[-1],
             }
             payload["objects"].append(file_obj)
             file_obj_size = len(json.dumps(file_obj, ensure_ascii=False).encode("utf8"))
             file_objs_size = file_objs_size + file_obj_size
             start_after += 1
     # For testing purposes:
-    # print(json.dumps(payload, indent=2))
+    print(json.dumps(payload, indent=2))
     return payload
 
 
 if __name__ == "__main__":
     sample_event = {
         "collection": "icesat2-boreal",
-        "inventory_url": "s3://maap-data-store-test/AGB_tindex_master.csv",
+        "inventory_url": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/AGB_tindex_master_train_data.csv",
         "discovery": "inventory",
         "file_url_key": "s3_path",
+        "csv_file_url_key": "s3_path_train",
         "upload": True,
+        "asset_name": "tif"
     }
 
     handler(sample_event, {})


### PR DESCRIPTION
Updates:
- updated `inventory` and `build-stac` lambda for generating STAC records for the TIFF and training data CSV files
- updated step function for the `icesat2-boreal` 

Expected behavior:
- Add `icesat2-boreal` training data CSVs to the TIFF files