### PR TITLE
fix cogify

### DIFF
--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -26,5 +26,15 @@
       }
     },
     "links": [],
-    "item_assets": {}
+    "item_assets": {
+      "tif": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data",
+              "layer"
+          ],
+          "title": "Cloud Optimized GeoTIFF",
+          "description": "Cloud Optimized GeoTIFF"
+      }        
+  }
 }

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -2,7 +2,7 @@
     "id": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
     "stac_version": "1.0.0",
     "license": "ESA CCI Data Policy: free and open access",
-    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2017",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4 Version 4, Year 2017",
     "type": "Collection",
     "description": "This dataset comprises estimates of forest above-ground biomass for the years 2017, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
     "extent": {

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -1,0 +1,30 @@
+{
+    "id": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
+    "stac_version": "1.0.0",
+    "license": "ESA CCI Data Policy: free and open access",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2017",
+    "type": "Collection",
+    "description": "This dataset comprises estimates of forest above-ground biomass for the years 2017, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2017-01-01T00:00:00.000Z",
+            "2017-12-31T23:59:59.999Z"
+          ]
+        ]
+      }
+    },
+    "links": [],
+    "item_assets": {}
+}

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -26,5 +26,15 @@
       }
     },
     "links": [],
-    "item_assets": {}
+    "item_assets": {
+      "tif": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data",
+              "layer"
+          ],
+          "title": "Cloud Optimized GeoTIFF",
+          "description": "Cloud Optimized GeoTIFF"
+      }        
+  }
 }

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -2,7 +2,7 @@
     "id": "ESACCI_Biomass_L4_AGB_V4_100m_2018",
     "stac_version": "1.0.0",
     "license": "ESA CCI Data Policy: free and open access",
-    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2018",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4 Version 4, Year 2018",
     "type": "Collection",
     "description": "This dataset comprises estimates of forest above-ground biomass for the years 2018, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
     "extent": {

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -1,0 +1,30 @@
+{
+    "id": "ESACCI_Biomass_L4_AGB_V4_100m_2018",
+    "stac_version": "1.0.0",
+    "license": "ESA CCI Data Policy: free and open access",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2018",
+    "type": "Collection",
+    "description": "This dataset comprises estimates of forest above-ground biomass for the years 2018, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2018-01-01T00:00:00.000Z",
+            "2018-12-31T23:59:59.999Z"
+          ]
+        ]
+      }
+    },
+    "links": [],
+    "item_assets": {}
+}

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -26,5 +26,15 @@
       }
     },
     "links": [],
-    "item_assets": {}
+    "item_assets": {
+      "tif": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data",
+              "layer"
+          ],
+          "title": "Cloud Optimized GeoTIFF",
+          "description": "Cloud Optimized GeoTIFF"
+      }        
+  }
 }

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -2,7 +2,7 @@
     "id": "ESACCI_Biomass_L4_AGB_V4_100m_2019",
     "stac_version": "1.0.0",
     "license": "ESA CCI Data Policy: free and open access",
-    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2019",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4 Version 4, Year 2019",
     "type": "Collection",
     "description": "This dataset comprises estimates of forest above-ground biomass for the years 2019, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
     "extent": {

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -1,0 +1,30 @@
+{
+    "id": "ESACCI_Biomass_L4_AGB_V4_100m_2019",
+    "stac_version": "1.0.0",
+    "license": "ESA CCI Data Policy: free and open access",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2019",
+    "type": "Collection",
+    "description": "This dataset comprises estimates of forest above-ground biomass for the years 2019, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2019-01-01T00:00:00.000Z",
+            "2019-12-31T23:59:59.999Z"
+          ]
+        ]
+      }
+    },
+    "links": [],
+    "item_assets": {}
+}

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -2,7 +2,7 @@
     "id": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
     "stac_version": "1.0.0",
     "license": "ESA CCI Data Policy: free and open access",
-    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2020",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4 Version 4, Year 2020",
     "type": "Collection",
     "description": "This dataset comprises estimates of forest above-ground biomass for the years 2020, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
     "extent": {

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -1,0 +1,30 @@
+{
+    "id": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
+    "stac_version": "1.0.0",
+    "license": "ESA CCI Data Policy: free and open access",
+    "title": "ESA CCI Above-Ground Biomass Product Level 4, Year 2020",
+    "type": "Collection",
+    "description": "This dataset comprises estimates of forest above-ground biomass for the years 2020, v4. They are derived from a combination of Earth observation data, depending on the year, from the Copernicus Sentinel-1 mission, Envisat’s ASAR instrument and JAXA’s Advanced Land Observing Satellite (ALOS-1 and ALOS-2), along with additional information from Earth observation sources. The data has been produced as part of the European Space Agency's (ESA's) Climate Change Initiative (CCI) programme by the Biomass CCI team.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2020-01-01T00:00:00.000Z",
+            "2020-12-31T23:59:59.999Z"
+          ]
+        ]
+      }
+    },
+    "links": [],
+    "item_assets": {}
+}

--- a/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/collections/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -26,5 +26,15 @@
       }
     },
     "links": [],
-    "item_assets": {}
+    "item_assets": {
+      "tif": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data",
+              "layer"
+          ],
+          "title": "Cloud Optimized GeoTIFF",
+          "description": "Cloud Optimized GeoTIFF"
+      }        
+  }
 }

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -1,0 +1,10 @@
+{
+  "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
+  "bucket": "maap-ops-workspace",
+  "prefix": "nehajo88/Data/CCI_2017/",
+  "filename_regex": "^(.*).tif$",
+  "discovery": "s3",
+  "upload": true,
+  "user_shared": true,
+  "cogify": true
+}

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -3,6 +3,6 @@
   "discovery": "inventory",
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2017.csv",
   "upload": true,
-  "user_shared": true,
+  "user_shared": false,
   "cogify": true
 }

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -1,9 +1,7 @@
 {
   "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
-  "bucket": "maap-ops-workspace",
-  "prefix": "nehajo88/Data/CCI_2017/",
-  "filename_regex": "^(.*).tif$",
-  "discovery": "s3",
+  "discovery": "inventory",
+  "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2017.csv",
   "upload": true,
   "user_shared": true,
   "cogify": true

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -5,5 +5,10 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path"
+  "csv_file_url_key": "s3_path",
+  "asset_roles": ["data"],
+  "asset_media_type": {
+          "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+    },
+  "asset_name": "tif"
 }

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -4,5 +4,6 @@
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2017.csv",
   "upload": true,
   "user_shared": false,
-  "cogify": true
+  "cogify": true,
+  "csv_file_url_key": "s3_path"
 }

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2017.json
@@ -5,7 +5,6 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path",
   "asset_roles": ["data"],
   "asset_media_type": {
           "tif": "image/tiff; application=geotiff; profile=cloud-optimized"

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -4,6 +4,7 @@
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2018.csv",
   "upload": true,
   "user_shared": false,
-  "cogify": true
+  "cogify": true,
+  "csv_file_url_key": "s3_path"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -1,0 +1,10 @@
+{
+  "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2018",
+  "bucket": "maap-ops-workspace",
+  "prefix": "nehajo88/Data/CCI_2018/",
+  "filename_regex": "^(.*).tif$",
+  "discovery": "s3",
+  "upload": true,
+  "user_shared": true,
+  "cogify": true
+}

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -1,10 +1,9 @@
 {
   "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2018",
-  "bucket": "maap-ops-workspace",
-  "prefix": "nehajo88/Data/CCI_2018/",
-  "filename_regex": "^(.*).tif$",
-  "discovery": "s3",
+  "discovery": "inventory",
+  "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2018.csv",
   "upload": true,
   "user_shared": true,
   "cogify": true
 }
+

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -3,7 +3,7 @@
   "discovery": "inventory",
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2018.csv",
   "upload": true,
-  "user_shared": true,
+  "user_shared": false,
   "cogify": true
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -5,6 +5,11 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path"
+  "csv_file_url_key": "s3_path",
+  "asset_roles": ["data"],
+  "asset_media_type": {
+          "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+    },
+  "asset_name": "tif"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2018.json
@@ -5,7 +5,6 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path",
   "asset_roles": ["data"],
   "asset_media_type": {
           "tif": "image/tiff; application=geotiff; profile=cloud-optimized"

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -1,10 +1,9 @@
 {
   "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2019",
-  "bucket": "maap-ops-workspace",
-  "prefix": "nehajo88/Data/CCI_2019/",
-  "filename_regex": "^(.*).tif$",
-  "discovery": "s3",
+  "discovery": "inventory",
+  "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2019.csv",
   "upload": true,
   "user_shared": true,
   "cogify": true
 }
+

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -3,7 +3,7 @@
   "discovery": "inventory",
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2019.csv",
   "upload": true,
-  "user_shared": true,
+  "user_shared": false,
   "cogify": true
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -5,6 +5,11 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path"
+  "csv_file_url_key": "s3_path",
+  "asset_roles": ["data"],
+  "asset_media_type": {
+          "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+    },
+  "asset_name": "tif"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -1,0 +1,10 @@
+{
+  "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2019",
+  "bucket": "maap-ops-workspace",
+  "prefix": "nehajo88/Data/CCI_2019/",
+  "filename_regex": "^(.*).tif$",
+  "discovery": "s3",
+  "upload": true,
+  "user_shared": true,
+  "cogify": true
+}

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -5,7 +5,6 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path",
   "asset_roles": ["data"],
   "asset_media_type": {
           "tif": "image/tiff; application=geotiff; profile=cloud-optimized"

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2019.json
@@ -4,6 +4,7 @@
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2019.csv",
   "upload": true,
   "user_shared": false,
-  "cogify": true
+  "cogify": true,
+  "csv_file_url_key": "s3_path"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -1,0 +1,10 @@
+{
+  "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
+  "bucket": "maap-ops-workspace",
+  "prefix": "nehajo88/Data/CCI_2020/",
+  "filename_regex": "^(.*).tif$",
+  "discovery": "s3",
+  "upload": true,
+  "user_shared": true,
+  "cogify": true
+}

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -4,6 +4,7 @@
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2020.csv",
   "upload": true,
   "user_shared": false,
-  "cogify": true
+  "cogify": true,
+  "csv_file_url_key": "s3_path"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -5,6 +5,11 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path"
+  "csv_file_url_key": "s3_path",
+  "asset_roles": ["data"],
+  "asset_media_type": {
+          "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+    },
+  "asset_name": "tif"
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -1,7 +1,7 @@
 {
   "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
   "discovery": "inventory",
-  "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2020.csv",
+  "inventory_url": "s3://maap-ops-workspace/emileten/CCI_2020.csv",
   "upload": true,
   "user_shared": false,
   "cogify": true,

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -5,7 +5,6 @@
   "upload": true,
   "user_shared": false,
   "cogify": true,
-  "csv_file_url_key": "s3_path",
   "asset_roles": ["data"],
   "asset_media_type": {
           "tif": "image/tiff; application=geotiff; profile=cloud-optimized"

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -3,7 +3,7 @@
   "discovery": "inventory",
   "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2020.csv",
   "upload": true,
-  "user_shared": true,
+  "user_shared": false,
   "cogify": true
 }
 

--- a/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
+++ b/data/step_function_inputs/ESACCI_Biomass_L4_AGB_V4_100m_2020.json
@@ -1,10 +1,9 @@
 {
   "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
-  "bucket": "maap-ops-workspace",
-  "prefix": "nehajo88/Data/CCI_2020/",
-  "filename_regex": "^(.*).tif$",
-  "discovery": "s3",
+  "discovery": "inventory",
+  "inventory_url": "s3://maap-ops-workspace/jjfrench/CCI_2020.csv",
   "upload": true,
   "user_shared": true,
   "cogify": true
 }
+

--- a/deploy/cdk/lambda_stack.py
+++ b/deploy/cdk/lambda_stack.py
@@ -124,7 +124,7 @@ class LambdaStack(core.Stack):
             f"{construct_id}-data-transfer-fn",
             "../lambdas/data-transfer",
             env={
-                "DATA_TRANSFER_BUCKET": config.DATA_TRANSFER_BUCKET,
+                "BUCKET": config.DATA_TRANSFER_BUCKET,
                 "USER_SHARED_BUCKET": config.USER_SHARED_BUCKET,
                 "DATA_MANAGEMENT_ROLE_ARN": config.DATA_MANAGEMENT_ROLE_ARN,
             },

--- a/deploy/cdk/lambda_stack.py
+++ b/deploy/cdk/lambda_stack.py
@@ -189,7 +189,9 @@ class LambdaStack(core.Stack):
 
         mcp_buckets = [
             self._bucket(bucket)
-            for bucket in config.MCP_BUCKETS.get(config.ENV, config.MCP_BUCKETS.get("stage"))
+            for bucket in config.MCP_BUCKETS.get(
+                config.ENV, config.MCP_BUCKETS.get("stage")
+            )
         ]
 
         external_buckets = [

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -13,10 +13,12 @@ APP_NAME = "maap-data-pipelines"
 MAAP_DATA_BUCKET = "maap-data-store"
 MAAP_EXTERNAL_BUCKETS = []
 MCP_BUCKETS = {
-    "prod": "nasa-maap-data-store",
-    "stage": "nasa-maap-data-store",
-    "dev": "nasa-maap-data-store",
+    "prod": ["nasa-maap-data-store","maap-ops-workspace"],
+    "stage": ["nasa-maap-data-store","maap-ops-workspace"],
+    "dev": ["nasa-maap-data-store","maap-ops-workspace"],
+    "test": ["nasa-maap-data-store","maap-ops-workspace"]
 }
+DATA_TRANSFER_BUCKET = "nasa-maap-data-store"
 USER_SHARED_BUCKET = "maap-user-shared-data"
 
 # This should throw if it is not provided

--- a/deploy/config.py
+++ b/deploy/config.py
@@ -13,10 +13,10 @@ APP_NAME = "maap-data-pipelines"
 MAAP_DATA_BUCKET = "maap-data-store"
 MAAP_EXTERNAL_BUCKETS = []
 MCP_BUCKETS = {
-    "prod": ["nasa-maap-data-store","maap-ops-workspace"],
-    "stage": ["nasa-maap-data-store","maap-ops-workspace"],
-    "dev": ["nasa-maap-data-store","maap-ops-workspace"],
-    "test": ["nasa-maap-data-store","maap-ops-workspace"]
+    "prod": ["nasa-maap-data-store", "maap-ops-workspace"],
+    "stage": ["nasa-maap-data-store", "maap-ops-workspace"],
+    "dev": ["nasa-maap-data-store", "maap-ops-workspace"],
+    "test": ["nasa-maap-data-store", "maap-ops-workspace"],
 }
 DATA_TRANSFER_BUCKET = "nasa-maap-data-store"
 USER_SHARED_BUCKET = "maap-user-shared-data"

--- a/lambdas/build-stac/handler.py
+++ b/lambdas/build-stac/handler.py
@@ -57,20 +57,13 @@ def handler(event: Dict[str, Any], context) -> Union[S3LinkOutput, StacItemOutpu
 
 if __name__ == "__main__":
     asset_event = {
-        "collection": "icesat2-boreal",
-        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831.tif",
-        "upload": True,
-        "user_shared": False,
-        "properties": None,
+        "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
         "asset_roles": ["data"],
-        "asset_name": "tif",
         "asset_media_type": {
-            "tif": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "csv": "text/csv",
+            "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
         },
-        "assets": {
-            "csv": "s3://nasa-maap-data-store/file-staging/nasa-map/icesat2-boreal/boreal_agb_202302061675671806_3831_train_data.csv"
-        },
-        "product_id": "boreal_agb_202302061675671806_3831",
+        "asset_name": "tif",
+        "remote_fileurl": "s3://nasa-maap-data-store/file-staging/nasa-map/N70E140_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif",
     }
+
     print(json.dumps(handler(asset_event, {}), indent=2))

--- a/lambdas/build-stac/requirements.txt
+++ b/lambdas/build-stac/requirements.txt
@@ -7,5 +7,5 @@ rasterio==1.3.0
 rio-stac==0.4.2
 shapely
 smart-open
-pydantic==1.9.1
+pydantic==1.10.8
 geojson==2.5.0

--- a/lambdas/build-stac/utils/regex.py
+++ b/lambdas/build-stac/utils/regex.py
@@ -34,10 +34,10 @@ def extract_dates(
     Extracts start & end or single date string from filename.
     """
     DATE_REGEX_STRATEGIES = [
-        (r"_(\d{4}-\d{2}-\d{2})", "%Y-%m-%d"),
-        (r"_(\d{8})", "%Y%m%d"),
-        (r"_(\d{6})", "%Y%m"),
-        (r"_(\d{4})", "%Y"),
+        (r"(?:_|-)(\d{4}-\d{2}-\d{2})", "%Y-%m-%d"),
+        (r"(?:_|-)(\d{8})", "%Y%m%d"),
+        (r"(?:_|-)(\d{6})", "%Y%m"),
+        (r"(?:_|-)(\d{4})", "%Y"),
     ]
 
     # Find dates in filename

--- a/lambdas/build-stac/utils/stac.py
+++ b/lambdas/build-stac/utils/stac.py
@@ -82,7 +82,7 @@ def create_item(
                     key: pystac_asset(value) for key, value in assets.items()
                 }
 
-            stac_record.assets = dict(stac_record.assets | pystac_assets)
+                stac_record.assets = dict(stac_record.assets | pystac_assets)
 
             return stac_record
         except Exception as e:

--- a/lambdas/cogify/example.ini
+++ b/lambdas/cogify/example.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
-output_bucket = climatedashboard-data 
-output_dir = OMDOAO3e_003 
+output_bucket = nasa-maap-data-store
+output_dir = file-staging/nasa-map 
 
 [GPM_3IMERGM]
 group = Grid

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -221,9 +221,8 @@ def geotiff_to_cog(upload: bool, **config):
 
 
 def handler(event, context):
-    
     return_obj = {**event}
-    
+
     filename = event["remote_fileurl"]
     collection = event["collection"]
 
@@ -244,28 +243,26 @@ def handler(event, context):
         raise ValueError(f"File type not supported: {filename}")
 
     return_obj.update(**output_locations)
-    
+
     print(f"Returning data: {return_obj}")
     return return_obj
 
 
 if __name__ == "__main__":
     sample_event = {
-    "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
-    "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif",
-    "upload": True,
-    "user_shared": False,
-    "properties": None,
-    "assets": {
-        "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif"
-    },
-    "product_id": "S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0",
-    "asset_roles": [
-        "data"
-    ],
-    "asset_media_type": {
-        "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
-    },
-    "asset_name": "tif"
+        "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
+        "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif",
+        "upload": True,
+        "user_shared": False,
+        "properties": None,
+        "assets": {
+            "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif"
+        },
+        "product_id": "S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0",
+        "asset_roles": ["data"],
+        "asset_media_type": {
+            "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+        },
+        "asset_name": "tif",
     }
     handler(sample_event, {})

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -40,7 +40,7 @@ def build_output_location(outfilename, collection):
 
 
 def upload_fileobject(file_obj, bucket, key):
-    print(f'uploading to s3://{bucket}/{key}')
+    print(f"uploading to s3://{bucket}/{key}")
     s3.upload_fileobj(file_obj, bucket, key)
 
 
@@ -88,8 +88,8 @@ def download_file(file_uri: str):
 
 def hdf5_to_cog(upload, **config):
     """HDF5 to COG."""
-    
-    # download 
+
+    # download
     filename = download_file(file_uri=config["filename"])
     # Open existing dataset
     variable_name = config["variable_name"]
@@ -198,21 +198,25 @@ def geotiff_to_cog(upload: bool, **config):
     gdal_config.update(config.get("gdal_config_options", {}) or {})
 
     # processing in memory, and then maybe upload to S3
-    
+
     with MemoryFile() as mem_dst:
-        
-        cog_translate(config["filename"], mem_dst.name, dst_kwargs=output_profile, config=gdal_config, in_memory=True, allow_intermediate_compression=True)
-    
+        cog_translate(
+            config["filename"],
+            mem_dst.name,
+            dst_kwargs=output_profile,
+            config=gdal_config,
+            in_memory=True,
+            allow_intermediate_compression=True,
+        )
+
         return_obj = {"filename": mem_dst.name}
-            
+
         if upload:
             target_bucket = output_bucket
             target_key = f"{output_dir}/{Path(config['filename']).parts[-1]}"
             upload_fileobject(mem_dst, target_bucket, target_key)
-            return_obj = {'remote_fileurl': f's3://{target_bucket}/{target_key}'}
-        
-    
-        
+            return_obj = {"remote_fileurl": f"s3://{target_bucket}/{target_key}"}
+
     return return_obj
 
 
@@ -220,11 +224,10 @@ def handler(event, context):
     filename = event["remote_fileurl"]
     collection = event["collection"]
 
-
     to_cog_config = {"filename": filename, "collection": collection}
     if event.get("gdal_config_options"):
         to_cog_config["gdal_config_options"] = event["gdal_config_options"]
-    
+
     return_obj = {"collection": event["collection"]}
 
     if filename.endswith(".he5"):
@@ -246,17 +249,15 @@ def handler(event, context):
 
 
 if __name__ == "__main__":
-    
-    
     sample_event = {
-    "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
-    "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif",
-    "upload": True,
-    "user_shared": False,
-    "properties": None,
-    "assets": {
-        "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif"
-    },
-    "product_id": "S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0"
+        "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
+        "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif",
+        "upload": True,
+        "user_shared": False,
+        "properties": None,
+        "assets": {
+            "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif"
+        },
+        "product_id": "S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0",
     }
     handler(sample_event, {})

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -221,14 +221,15 @@ def geotiff_to_cog(upload: bool, **config):
 
 
 def handler(event, context):
+    
+    return_obj = {**event}
+    
     filename = event["remote_fileurl"]
     collection = event["collection"]
 
     to_cog_config = {"filename": filename, "collection": collection}
     if event.get("gdal_config_options"):
         to_cog_config["gdal_config_options"] = event["gdal_config_options"]
-
-    return_obj = {"collection": event["collection"]}
 
     if filename.endswith(".he5"):
         config._sections[collection]
@@ -242,22 +243,29 @@ def handler(event, context):
     else:
         raise ValueError(f"File type not supported: {filename}")
 
-    return_obj = {**return_obj, **output_locations}
-
+    return_obj.update(**output_locations)
+    
     print(f"Returning data: {return_obj}")
     return return_obj
 
 
 if __name__ == "__main__":
     sample_event = {
-        "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2017",
-        "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif",
-        "upload": True,
-        "user_shared": False,
-        "properties": None,
-        "assets": {
-            "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2017/S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0.tif"
-        },
-        "product_id": "S20W060_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2017-fv4.0",
+    "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
+    "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif",
+    "upload": True,
+    "user_shared": False,
+    "properties": None,
+    "assets": {
+        "csv": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0.tif"
+    },
+    "product_id": "S50W070_ESACCI-BIOMASS-L4-AGB_SD-MERGED-100m-2020-fv4.0",
+    "asset_roles": [
+        "data"
+    ],
+    "asset_media_type": {
+        "tif": "image/tiff; application=geotiff; profile=cloud-optimized"
+    },
+    "asset_name": "tif"
     }
     handler(sample_event, {})

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -217,6 +217,8 @@ def handler(event, context):
     downloaded_filename = download_file(file_uri=filename)
 
     to_cog_config = {"filename": downloaded_filename, "collection": collection}
+    if event.get("gdal_config_options"):
+        to_cog_config["gdal_config_options"] = event["gdal_config_options"]
     return_obj = {"collection": event["collection"]}
 
     if filename.endswith(".he5"):

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -189,6 +189,7 @@ def geotiff_to_cog(upload: bool, **config):
         GDAL_TIFF_INTERNAL_MASK=True,
         GDAL_TIFF_OVR_BLOCKSIZE="128",
     )
+    gdal_config.update(config.get("gdal_config_options", {}) or {})
 
     filename = config["filename"]
 
@@ -215,10 +216,7 @@ def handler(event, context):
     collection = event["collection"]
     downloaded_filename = download_file(file_uri=filename)
 
-    to_cog_config = {}
-    to_cog_config["filename"] = downloaded_filename
-    to_cog_config["collection"] = collection
-
+    to_cog_config = {"filename": downloaded_filename, "collection": collection}
     return_obj = {"collection": event["collection"]}
 
     if filename.endswith(".he5"):

--- a/lambdas/cogify/handler.py
+++ b/lambdas/cogify/handler.py
@@ -213,7 +213,7 @@ def geotiff_to_cog(upload: bool, **config):
 
         if upload:
             target_bucket = output_bucket
-            target_key = f"{output_dir}/{Path(config['filename']).parts[-1]}"
+            target_key = f"{output_dir}/{config['collection']}/{Path(config['filename']).parts[-1]}"
             upload_fileobject(mem_dst, target_bucket, target_key)
             return_obj = {"remote_fileurl": f"s3://{target_bucket}/{target_key}"}
 

--- a/lambdas/s3-discovery/handler.py
+++ b/lambdas/s3-discovery/handler.py
@@ -72,6 +72,8 @@ def handler(event, context):
                 "properties": properties,
                 **date_fields,
             }
+            if event.get("gdal_config_options"):
+                file_obj["gdal_config_options"] = event["gdal_config_options"]
             payload["objects"].append(file_obj)
             file_obj_size = len(json.dumps(file_obj, ensure_ascii=False).encode("utf8"))
             file_objs_size = file_objs_size + file_obj_size


### PR DESCRIPTION
The cogify code had deprecated CMR logic in it and only supports an HDF5 -> COG case with pretty custom conversion settings. 

For the purpose of https://github.com/MAAP-Project/ZenHub/issues/709 : 

- [x] removing CMR logic from the cogify lambda
- [x] adding a geotiff -> cloud optimized geotiff case using the default rio cogeo settings. 

The lambda was tested locally, with SMCE credentials. 

Input event : 


```
    sample_event = {
        "collection": "ESACCI_Biomass_L4_AGB_V4_100m_2020",
        "remote_fileurl": "s3://maap-ops-workspace/nehajo88/Data/CCI_2020/N00E000_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2020-fv4.0.tif",
        "upload": True,
    }
```

Which saved the COG to `s3://nasa-maap-data-store/file-staging/nasa-map/ESACCI_Biomass_L4_AGB_V4_100m_2020/N00E000_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2020-fv4.0.tif`. I checked it's a valid COG with `rio cogeo validate ...`. 

One can also check a view at https://titiler-stac.maap-project.org/cog/viewer?url=s3://nasa-maap-data-store/file-staging/nasa-map/ESACCI_Biomass_L4_AGB_V4_100m_2020/N00E000_ESACCI-BIOMASS-L4-AGB-MERGED-100m-2020-fv4.0.tif. 

